### PR TITLE
ci(alpha-ci): add pnpm install action 

### DIFF
--- a/.github/workflows/alpha-ci.yml
+++ b/.github/workflows/alpha-ci.yml
@@ -25,6 +25,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 6.32.9
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
#### Description

ci failed after enabling pnpm cache. To use pnpm cache pnpm should be setup. https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md\#caching-packages-data

closes https://github.com/wednesday-solutions/fastify-postgres/issues/14

Signed-off-by: christin-wednesday <christin@wednesday.is>