### PR TITLE
fix: added fastify-custom-errors to npm scripts and fixed imports

### DIFF
--- a/packages/fastify-custom-errors/package.json
+++ b/packages/fastify-custom-errors/package.json
@@ -8,7 +8,7 @@
     "tsconfig": "workspace:*"
   },
   "scripts": {
-    "test": "jest --silent --verbose --testPathPattern=test"
+    "test:unit": "jest --silent --verbose --testPathPattern=test"
   },
   "devDependencies": {
     "@types/node": "^18.11.18",

--- a/packages/fastify-custom-errors/test/errors.test.ts
+++ b/packages/fastify-custom-errors/test/errors.test.ts
@@ -1,4 +1,3 @@
-import UnprocessableEntity from '@src/errors/unprocessable-entity.error';
 import {
   BadRequestError,
   ForbiddenError,
@@ -10,7 +9,8 @@ import {
   NotImplementedError,
   TooManyRequestsError,
   UnauthorizedError,
-} from '@src/index';
+  UnprocessableEntityError,
+} from '../src/index';
 
 describe('Errors', () => {
   describe('badRequestError', () => {
@@ -191,7 +191,7 @@ describe('Errors', () => {
   describe('unprocessableEntity', () => {
     it('throws an exception with a message', () => {
       try {
-        throw new UnprocessableEntity('Unprocessable Entity!');
+        throw new UnprocessableEntityError('Unprocessable Entity!');
       } catch (error) {
         expect(error).toEqual(new Error('Unprocessable Entity!'));
         expect((error as CustomError).message).toEqual('Unprocessable Entity!');
@@ -202,7 +202,7 @@ describe('Errors', () => {
 
     it('serializes errors and return in a proper structure', () => {
       try {
-        throw new UnprocessableEntity('Unprocessable Entity!');
+        throw new UnprocessableEntityError('Unprocessable Entity!');
       } catch (error) {
         if (error instanceof CustomError) {
           expect(error.serializeErrors()).toEqual([


### PR DESCRIPTION
## PR Checklist

- [NA] Added tests to prevent future regressions
- [NA] Updated the documentation for changes made
- [x] Your code follows the guidelines
- [NA] Provided link to the issue this closes

## Description

Fixed the imports for `fasitfy-custom-errors` and added `test:unit` npm script to `fastify-custom-errors`.

## How to Test

Run `pnpm run test:unit` from root and `fastify-custom-errors` should automatically be included.
