### PR TITLE
chore: reconcile and update pnpm-lock file with package.json

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,10 +3,6 @@ lockfileVersion: '6.0'
 importers:
 
   .:
-    dependencies:
-      dotenv-cli:
-        specifier: ^7.0.0
-        version: 7.0.0
     devDependencies:
       '@types/jest':
         specifier: ^29.2.6


### PR DESCRIPTION
## PR Checklist

- [NA] Added tests to prevent future regressions
- [NA] Updated the documentation for changes made
- [NA] Your code follows the guidelines
- [NA] Provided link to the issue this closes

## Description

Recent merges caused the `pnpm-lock.yaml` to go out-of-sync with `package.json` causing `frozen-lockfile` installation to fail!
